### PR TITLE
conversion logic & unit tests fixed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export namespace Simply {
      * From Unix epoch
      * @param dt 1514851200000
      */
-    const fromNumber = (dt: number): SimplyDate => from.date(new Date(dt));
+    const fromMsSinceEpoch = (dt: number): SimplyDate => from.date(new Date(dt));
 
     /**
      *
@@ -54,7 +54,7 @@ export namespace Simply {
 
     export const from = {
         date: fromDate,
-        number: fromNumber,
+        msSinceEpoch: fromMsSinceEpoch,
         string: fromString
     };
 
@@ -70,19 +70,19 @@ export namespace Simply {
 
     /**
      * Returns the number of milliseconds in a SimplyDate object since January 1, 1970, 00:00:00, universal time.
+     * Equivalent to getTime of the JavaScript Date object.
      * @param {SimplyDate} sDt
      * @returns {number}
      */
-    const toNumber = (sDt: SimplyDate): number =>
-        Date.UTC(sDt.year, sDt.month - 1, sDt.day, sDt.hour, sDt.minute, sDt.second, sDt.millisecond);
-
-    // const toIsoNumber = (sDt: SimplyDate, timezoneOffsetInMilliseconds: number): number => {
-    //     return toNumber(Simply.subtract(timezoneOffsetInMilliseconds).milliseconds.from(sDt));
-    // };
+    const toMsSinceEpoch = (sDt: SimplyDate): number => {
+        const dt = new Date();
+        const _sdt = Simply.add(dt.getTimezoneOffset()).minutes.to(sDt);
+        return Date.UTC(_sdt.year, _sdt.month - 1, _sdt.day, _sdt.hour, _sdt.minute, _sdt.second, _sdt.millisecond);
+    };
 
     export const to = {
         date: toDate,
-        number: toNumber
+        msSinceEpoch: toMsSinceEpoch
     };
 
     export const now = (): SimplyDate => {

--- a/test/parsing.spec.ts
+++ b/test/parsing.spec.ts
@@ -13,8 +13,8 @@ describe('parsing.spec.ts parsing strings should', () => {
         expect(millisecond).to.equal(0);
     });
 
-    it('2.0 after parsing from number, should yield back the same number', () => {
-        const sDt = Simply.from.number(1515035460000);
+    it('2.0 after parsing from milliseconds since the Epoch, should provide the expected time unit values', () => {
+        const sDt = Simply.from.msSinceEpoch(1515035460000);
         expect(sDt.year).to.equal(2018);
         expect(sDt.month).to.equal(1);
         expect(sDt.day).to.equal(4);
@@ -23,20 +23,21 @@ describe('parsing.spec.ts parsing strings should', () => {
     });
 
     it('3.0 parsing number and converting it back', () => {
-        const startDate = Date.UTC(2018, 8, 14, 9, 4, 3, 455);
+        const fromUnixEpoch = Date.UTC(2018, 8, 14, 9, 4, 3, 455);
         // const timestamp = Date.UTC(now.year, now.month, now.day, now.hour, now.minute, now.second, now.millisecond);
-        expect(startDate).to.equal(1536915843455);
+        expect(fromUnixEpoch).to.equal(1536915843455);
         const dt = new Date(1536915843455);
-        expect(dt.getTime()).to.equal(startDate);
-        // const MSEC = 1515035460000;
-        const sDt = Simply.subtract(dt.getTimezoneOffset() * 60000).minutes.from(Simply.from.number(startDate));
+        expect(dt.getTime()).to.equal(fromUnixEpoch);
+        const sDt = Simply.from.msSinceEpoch(fromUnixEpoch);
+        // const offsetHours = dt.getTimezoneOffset();
+        // expect(offsetHours).to.equal(120);
         expect(sDt.millisecond).to.equal(455);
         expect(sDt.second).to.equal(3);
         expect(sDt.minute).to.equal(4);
-        expect(sDt.hour).to.equal(9);
+        expect(sDt.hour).to.equal(11); // we are looking at the local computer time in this case
         expect(sDt.day).to.equal(14);
         expect(sDt.month).to.equal(9); // javascript month starts from 0, SimplyDate from 1
         expect(sDt.year).to.equal(2018);
-        expect(Simply.to.number(sDt)).to.equal(startDate);
+        expect(Simply.to.msSinceEpoch(sDt)).to.equal(fromUnixEpoch);
     });
 });


### PR DESCRIPTION
The conversion function was not taking into account the timezone offset. Fixed now.